### PR TITLE
FIX: remove struk message deletion logic

### DIFF
--- a/src/query.py
+++ b/src/query.py
@@ -336,8 +336,6 @@ async def parse_query(query, client, debug=False):
         ret.append((actions.REACT, ["🇬", "🇲", "baj"]))
     if query.author.id == TUS_ID:
         ret.append((actions.REACT, ["tus"]))
-    if STRUK_ID in [x.id for x in query.author.roles]:
-        ret.append((actions.REMOVE, None))
     if query.channel.id == TUS_THREAD_ID:
         ret.append((actions.REMOVE, None))
     elif re.search(r"(\W|_|\d|^)(gn|գն|bg|բգ|gngn|գնգն|bgbg|բգբգ)(\W|_|\d|$)", content, flags=re.UNICODE | re.IGNORECASE):


### PR DESCRIPTION
Removed logic to delete Struks' messaged, as it was added to not allow Struks to write in threads, which is a functionality added by discord. Now it just deletes messages of people regardless of their highest role if they have struk, which is unwanted.