### PR TITLE
FIX: add delay before each react

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -63,6 +63,7 @@ def main():
                 elif action == actions.REACT:
                     for emoji_id in response:
                         emoji = get(client.emojis, name=emoji_id)
+                        await asyncio.sleep(0.3) # discord bugs out and doesn't display these reacts client-side
                         await message.add_reaction(emoji or emoji_id)
                 elif action == actions.BUTTONS:
                     sent = await message.reply(embed=response["embed"])


### PR DESCRIPTION
Added small delay before each react - sometimes when the bot reacts the message hasn't propagated yet and the reacts don't register client-side, but they exist server-side. When the user adds a react, it the react remove logic works anyway (since it exists server-side) and on the user's end their own react gets removed. They have to react again, which un-reacts server-side, then Luke re-reacts, and only then does it get fixed. This should fix the issue.

Also please siktir my intelinair github account from the repo